### PR TITLE
Added dimOpacity option to set alpha for overlay

### DIFF
--- a/Hover/Model/HoverConfiguration.swift
+++ b/Hover/Model/HoverConfiguration.swift
@@ -32,6 +32,8 @@ public struct HoverConfiguration {
     public var font: UIFont?
     /// Color of the overlay
     public var dimColor: UIColor
+    /// Opacity of the overlay
+    public var dimOpacity: CGFloat
     /// Initial position of the floating button
     public var initialPosition: HoverPosition
     /// Allowed positions in which the floating button can be placed
@@ -53,6 +55,7 @@ public struct HoverConfiguration {
                 spacing: CGFloat = 12.0,
                 font: UIFont? = nil,
                 dimColor: UIColor = UIColor.black.withAlphaComponent(0.75),
+                dimOpacity: CGFloat = 0.5,
                 initialPosition: HoverPosition = .bottomRight,
                 allowedPositions: Set<HoverPosition> = .all) {
         
@@ -63,6 +66,7 @@ public struct HoverConfiguration {
         self.spacing = spacing
         self.font = font
         self.dimColor = dimColor
+        self.dimOpacity = dimOpacity < 0 || dimOpacity > 1 ? 0.5 : dimOpacity
         self.initialPosition = initialPosition
         self.allowedPositions = allowedPositions
     }

--- a/Hover/UI/HoverView.swift
+++ b/Hover/UI/HoverView.swift
@@ -253,7 +253,7 @@ private extension HoverView {
         itemsStackView.isUserInteractionEnabled = isOpening
         
         UIViewPropertyAnimator(duration: Constant.animationDuration, curve: .easeInOut) {
-            self.dimView.alpha = isOpening ? 1.0 : 0.0
+            self.dimView.alpha = isOpening ? self.configuration.dimOpacity : 0.0
         }.startAnimation()
         
         anchor.position.yOrientation.reverseArrayIfNeeded(itemsStackView.arrangedSubviews).enumerated().forEach { (index, view) in

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once imported, you can start using **Hover** like follows:
 
 ```swift
 // Create Hover's Configuration (all parameters have defaults)
-let configuration = HoverConfiguration(icon: UIImage(named: "add"), color: .gradient(top: .blue, bottom: .cyan))
+let configuration = HoverConfiguration(image: UIImage(named: "add"), color: .gradient(top: .blue, bottom: .cyan), dimColor: .black, dimOpacity: 0.5)
 
 // Create the items to display
 let items = [


### PR DESCRIPTION
Added the option for users to dim the opacity of the overlay as I find sometimes the default 1.0 might not be what users want and the only way to have a semi transparent at the moment is if you do not put an overlay color.

I've attached 2 videos showing opacity 0.8 and 0.2 for reference.

https://user-images.githubusercontent.com/32763588/104430518-e188c300-55da-11eb-9078-20c3740e5b4d.mov

https://user-images.githubusercontent.com/32763588/104430534-e8afd100-55da-11eb-9db7-cd6389a23d51.mov

Let me know if there's anything.
Thank you