### PR TITLE
Fix typo on readme sample code and make HoverItem image optional

### DIFF
--- a/Hover.podspec
+++ b/Hover.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name = 'Hover'
-    spec.version = '1.3.1'
+    spec.version = '1.3.2'
     spec.license = { :type => 'MIT', :file => 'LICENSE' }
     spec.homepage = 'https://github.com/pedrommcarrasco/Hover'
     spec.authors = { 'Pedro Carrasco' => 'https://twitter.com/pedrommcarrasco' }

--- a/Hover/Model/HoverItem.swift
+++ b/Hover/Model/HoverItem.swift
@@ -13,11 +13,11 @@ public struct HoverItem {
     
     // MARK: Properties
     let title: String?
-    let image: UIImage
+    let image: UIImage?
     let onTap: () -> ()
     
     // MARK: Lifecycle
-    public init(title: String? = nil, image: UIImage, onTap: @escaping () -> ()) {
+    public init(title: String? = nil, image: UIImage?, onTap: @escaping () -> ()) {
         self.title = title
         self.image = image
         self.onTap = onTap

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once imported, you can start using **Hover** like follows:
 
 ```swift
 // Create Hover's Configuration (all parameters have defaults)
-let configuration = HoverConfiguration(icon: UIImage(named: "add"), color: .gradient(top: .blue, bottom: .cyan))
+let configuration = HoverConfiguration(image: UIImage(named: "add"), color: .gradient(top: .blue, bottom: .cyan))
 
 // Create the items to display
 let items = [


### PR DESCRIPTION
Sample code refers to "image" field as "icon" instead of "image". Also, change HoverItem specification to take image as an optional value.