### PR TITLE
Added way to enable rotation animation when expanding items

### DIFF
--- a/Hover.podspec
+++ b/Hover.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name = 'Hover'
-    spec.version = '1.4.0'
+    spec.version = '1.5.0'
     spec.license = { :type => 'MIT', :file => 'LICENSE' }
     spec.homepage = 'https://github.com/pedrommcarrasco/Hover'
     spec.authors = { 'Pedro Carrasco' => 'https://twitter.com/pedrommcarrasco' }

--- a/Hover/Model/HoverConfiguration.swift
+++ b/Hover/Model/HoverConfiguration.swift
@@ -36,6 +36,8 @@ public struct HoverConfiguration {
     public var initialPosition: HoverPosition
     /// Allowed positions in which the floating button can be placed
     public var allowedPositions: Set<HoverPosition>
+    /// Define the animation of the HoverButton's image when expding items
+    public var imageExpandAnimation: ImageExpandAnimation
     
     var itemConfiguration: HoverItemConfiguration {
         return HoverItemConfiguration(size: size * Constant.itemSizeRatio,
@@ -54,7 +56,8 @@ public struct HoverConfiguration {
                 font: UIFont? = nil,
                 dimColor: UIColor = UIColor.black.withAlphaComponent(0.75),
                 initialPosition: HoverPosition = .bottomRight,
-                allowedPositions: Set<HoverPosition> = .all) {
+                allowedPositions: Set<HoverPosition> = .all,
+                imageExpandAnimation: ImageExpandAnimation = .none) {
         
         self.color = color
         self.image = image
@@ -65,6 +68,7 @@ public struct HoverConfiguration {
         self.dimColor = dimColor
         self.initialPosition = initialPosition
         self.allowedPositions = allowedPositions
+        self.imageExpandAnimation = imageExpandAnimation
     }
 }
 
@@ -76,5 +80,15 @@ struct HoverItemConfiguration {
     let margin: CGFloat
     let font: UIFont?
     let initialXOrientation: Orientation.X
+}
+
+// MARK: - ImageExpandAnimation
+public enum ImageExpandAnimation {
+    // No animation
+    case none
+
+    // Rotate considering the radian value.
+    // It considers the X and Y orientation when animating.
+    case rotate(_ radian: CGFloat)
 }
 

--- a/Hover/Model/HoverConfiguration.swift
+++ b/Hover/Model/HoverConfiguration.swift
@@ -87,7 +87,6 @@ public enum ImageExpandAnimation {
     /// No animation
     case none
 
-    // Rotate considering the radian value.
-    // It considers the X and Y orientation when animating.
+    /// Rotate considering the radian value. It considers the X and Y orientation when animating.
     case rotate(_ radian: CGFloat)
 }

--- a/Hover/Model/HoverConfiguration.swift
+++ b/Hover/Model/HoverConfiguration.swift
@@ -84,11 +84,10 @@ struct HoverItemConfiguration {
 
 // MARK: - ImageExpandAnimation
 public enum ImageExpandAnimation {
-    // No animation
+    /// No animation
     case none
 
     // Rotate considering the radian value.
     // It considers the X and Y orientation when animating.
     case rotate(_ radian: CGFloat)
 }
-

--- a/Hover/Model/HoverConfiguration.swift
+++ b/Hover/Model/HoverConfiguration.swift
@@ -22,6 +22,8 @@ public struct HoverConfiguration {
     public var color: HoverColor
     /// Image displayed in the floating button
     public var image: UIImage?
+    /// Define the animation of the HoverButton's image when expding items
+    public var imageExpandAnimation: ImageExpandAnimation
     /// Size of the floating button
     public var size: CGFloat
     /// Dictates the size of the image shown in any button (imageSize = size * imageSizeRatio)
@@ -36,8 +38,6 @@ public struct HoverConfiguration {
     public var initialPosition: HoverPosition
     /// Allowed positions in which the floating button can be placed
     public var allowedPositions: Set<HoverPosition>
-    /// Define the animation of the HoverButton's image when expding items
-    public var imageExpandAnimation: ImageExpandAnimation
     
     var itemConfiguration: HoverItemConfiguration {
         return HoverItemConfiguration(size: size * Constant.itemSizeRatio,
@@ -49,6 +49,7 @@ public struct HoverConfiguration {
     
     // MARK: Init
     public init(image: UIImage? = nil,
+                imageExpandAnimation: ImageExpandAnimation = .none,
                 color: HoverColor = .color(.blue),
                 size: CGFloat = 60.0,
                 imageSizeRatio: CGFloat = 0.4,
@@ -56,11 +57,11 @@ public struct HoverConfiguration {
                 font: UIFont? = nil,
                 dimColor: UIColor = UIColor.black.withAlphaComponent(0.75),
                 initialPosition: HoverPosition = .bottomRight,
-                allowedPositions: Set<HoverPosition> = .all,
-                imageExpandAnimation: ImageExpandAnimation = .none) {
+                allowedPositions: Set<HoverPosition> = .all) {
         
         self.color = color
         self.image = image
+        self.imageExpandAnimation = imageExpandAnimation
         self.size = size
         self.imageSizeRatio = imageSizeRatio
         self.spacing = spacing
@@ -68,7 +69,6 @@ public struct HoverConfiguration {
         self.dimColor = dimColor
         self.initialPosition = initialPosition
         self.allowedPositions = allowedPositions
-        self.imageExpandAnimation = imageExpandAnimation
     }
 }
 

--- a/Hover/UI/HoverButton.swift
+++ b/Hover/UI/HoverButton.swift
@@ -18,7 +18,6 @@ class HoverButton: UIControl {
         static let animationDuration = 0.5
         static let animationDamping: CGFloat = 0.4
         static let highlightColor = UIColor.white.withAlphaComponent(0.2)
-        static let rotationTransform = CGAffineTransform(rotationAngle: .pi * -0.25)
     }
     
     // MARK: Outlets
@@ -53,13 +52,17 @@ class HoverButton: UIControl {
 
     var isExpanded: Bool = false {
         didSet {
-            let transform: CGAffineTransform = isExpanded ? Constant.rotationTransform : .identity
+            let rotationValue: CGFloat = (.pi * 0.25) * (orientation == .leftToRight ? 1 : -1)
+            let rotationTransform = CGAffineTransform(rotationAngle: rotationValue)
+            let transform: CGAffineTransform = isExpanded ? rotationTransform: .identity
 
             UIViewPropertyAnimator(duration: Constant.animationDuration, dampingRatio: Constant.animationDamping) {
                 self.imageView.transform = transform
             }.startAnimation()
         }
     }
+
+    var orientation: Orientation.X = .rightToLeft
     
     // MARK: Lifecycle
     init(with color: HoverColor, image: UIImage?, imageSizeRatio: CGFloat) {

--- a/Hover/UI/HoverButton.swift
+++ b/Hover/UI/HoverButton.swift
@@ -21,11 +21,11 @@ class HoverButton: UIControl {
     }
     
     // MARK: Outlets
-    private var gradientLayer: CAGradientLayer?
-    private let imageView: UIImageView = .create {
+    let imageView: UIImageView = .create {
         $0.contentMode = .scaleAspectFit
         $0.isUserInteractionEnabled = false
     }
+    private var gradientLayer: CAGradientLayer?
     private let hightlightView: UIView = .create {
         $0.backgroundColor = Constant.highlightColor
         $0.isUserInteractionEnabled = false
@@ -49,20 +49,6 @@ class HoverButton: UIControl {
             }.startAnimation()
         }
     }
-
-    var isExpanded: Bool = false {
-        didSet {
-            let rotationValue: CGFloat = (.pi * 0.25) * (orientation == .leftToRight ? 1 : -1)
-            let rotationTransform = CGAffineTransform(rotationAngle: rotationValue)
-            let transform: CGAffineTransform = isExpanded ? rotationTransform: .identity
-
-            UIViewPropertyAnimator(duration: Constant.animationDuration, dampingRatio: Constant.animationDamping) {
-                self.imageView.transform = transform
-            }.startAnimation()
-        }
-    }
-
-    var orientation: Orientation.X = .rightToLeft
     
     // MARK: Lifecycle
     init(with color: HoverColor, image: UIImage?, imageSizeRatio: CGFloat) {

--- a/Hover/UI/HoverButton.swift
+++ b/Hover/UI/HoverButton.swift
@@ -18,6 +18,7 @@ class HoverButton: UIControl {
         static let animationDuration = 0.5
         static let animationDamping: CGFloat = 0.4
         static let highlightColor = UIColor.white.withAlphaComponent(0.2)
+        static let rotationTransform = CGAffineTransform(rotationAngle: .pi * -0.25)
     }
     
     // MARK: Outlets
@@ -46,6 +47,16 @@ class HoverButton: UIControl {
             UIViewPropertyAnimator(duration: Constant.animationDuration, dampingRatio: Constant.animationDamping) {
                 self.transform = transform
                 self.hightlightView.alpha = alpha
+            }.startAnimation()
+        }
+    }
+
+    var isExpanded: Bool = false {
+        didSet {
+            let transform: CGAffineTransform = isExpanded ? Constant.rotationTransform : .identity
+
+            UIViewPropertyAnimator(duration: Constant.animationDuration, dampingRatio: Constant.animationDamping) {
+                self.imageView.transform = transform
             }.startAnimation()
         }
     }

--- a/Hover/UI/HoverView.swift
+++ b/Hover/UI/HoverView.swift
@@ -250,13 +250,10 @@ private extension HoverView {
 
     private func animate(isOpening: Bool, anchor: Anchor, completion: (() -> Void)? = nil) {
         itemsStackView.isUserInteractionEnabled = isOpening
-        
-        UIViewPropertyAnimator(duration: Constant.animationDuration, curve: .easeInOut) {
-            self.dimView.alpha = isOpening ? 1.0 : 0.0
-        }.startAnimation()
 
         let transform = imageExpandTransform(isOpening: isOpening)
         UIViewPropertyAnimator(duration: Constant.animationDuration, dampingRatio: Constant.animationDamping) {
+            self.dimView.alpha = isOpening ? 1.0 : 0.0
             self.button.imageView.transform = transform
         }.startAnimation()
         

--- a/Hover/UI/HoverView.swift
+++ b/Hover/UI/HoverView.swift
@@ -285,7 +285,6 @@ private extension HoverView {
             return .identity
             
         case .rotate(let radianValue):
-
             let factor: CGFloat
 
             switch (currentAnchor.position.xOrientation, currentAnchor.position.yOrientation) {

--- a/Hover/UI/HoverView.swift
+++ b/Hover/UI/HoverView.swift
@@ -21,7 +21,6 @@ public class HoverView: UIView {
         static let interItemSpacing: CGFloat = 12.0
         static let disabledAlpha: CGFloat = 0.75
         static let disabledTransform = CGAffineTransform(scaleX: 0.9, y: 0.9)
-        
     }
     
     // MARK: State
@@ -251,6 +250,7 @@ private extension HoverView {
     
     private func animate(isOpening: Bool, anchor: Anchor, completion: (() -> Void)? = nil) {
         itemsStackView.isUserInteractionEnabled = isOpening
+        button.isExpanded = isOpening
         
         UIViewPropertyAnimator(duration: Constant.animationDuration, curve: .easeInOut) {
             self.dimView.alpha = isOpening ? 1.0 : 0.0

--- a/Hover/UI/HoverView.swift
+++ b/Hover/UI/HoverView.swift
@@ -302,5 +302,6 @@ private extension HoverView {
         NSLayoutConstraint.activate([stackViewXConstraint, stackViewYConstraint])
         
         itemViews.forEach { $0.orientation = currentAnchor.position.xOrientation }
+        button.orientation = currentAnchor.position.xOrientation
     }
 }


### PR DESCRIPTION
This PR resolves #16

- Added new enum `ImageExpandAnimation` with the options `none` and `rotate(radian)`
- Added a new config value to `HoverConfiguration`
- The rotation animation considers the current HoverButton's position

Example:
```swift
let configuration = HoverConfiguration(
    image: UIImage("plus"),
    imageExpandAnimation: .rotate(.pi * 0.25)
)
```